### PR TITLE
Add Github action for pushing expo update

### DIFF
--- a/.github/workflows/build_update.yml
+++ b/.github/workflows/build_update.yml
@@ -1,0 +1,40 @@
+name: Create Expo Preview
+
+on:
+    push:
+        branches:
+            - develop
+
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    publish-preview:
+        runs-on: ubuntu-latest
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            EXPO_PROJECT: ${{ vars.EXPO_PROJECT }}
+            EXPO_PUBLIC_SB_URL: ${{ vars.SUPABASE_URL_DEV }}
+            EXPO_PUBLIC_SB_ANON: ${{ secrets.SUPABASE_ANON_DEV }}
+        steps:
+            - name: 🏗 Setup repo
+              uses: actions/checkout@v3
+
+            - name: 🏗 Setup Node
+              uses: actions/setup-node@v3
+
+            - name: 🏗 Setup EAS
+              uses: expo/expo-github-action@v8
+              with:
+                  eas-version: latest
+                  packager: npm
+                  token: ${{ secrets.EXPO_TOKEN }}
+
+            - name: 📦 Install dependencies
+              run: npm install
+
+            - name: 🚀 Create preview
+              uses: expo/expo-github-action/preview@v8
+              with:
+                  command: eas update --branch ${{ github.ref_name }} --message ${{ github.event.head_commit.message }}


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- New Feature: Introduced a GitHub Actions workflow for the `develop` branch. This workflow automatically creates an Expo preview whenever changes are pushed to the branch, enhancing the development process by providing immediate visual feedback on updates.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->