### PR TITLE
refactor: Remove visited node after traversal in `CardRelationManager` and add test case for no cycle in `set` function.

### DIFF
--- a/__tests__/lib/CardRelationManager.test.ts
+++ b/__tests__/lib/CardRelationManager.test.ts
@@ -19,6 +19,14 @@ const mockedRelations2 = [
   { parent: '3', child: '1' },
 ] as CardRelation[]
 
+const mockedRelations3 = [
+  { parent: '1', child: '2' },
+  { parent: '2', child: '3' },
+  { parent: '2', child: '4' },
+  { parent: '3', child: '5' },
+  { parent: '4', child: '5' },
+] as CardRelation[]
+
 const mockedRelationsWithCycle = [
   { parent: '1', child: '2' },
   { parent: '1', child: '3' },
@@ -99,6 +107,13 @@ describe('set', () => {
       // @ts-ignore
       expect(CardRelationManager.parents).toEqual(expectedParents)
     })
+  })
+
+  it('should not throw an error if there is no cycle', () => {
+    // @ts-ignore
+    CardRelationManager.set(mockedRelations3)
+    // @ts-ignore
+    expect(() => CardRelationManager.set(skiturStoryRelation)).not.toThrow(CycleError)
   })
 
   const cycles = [mockedRelationsWithCycle, mockedRelationsWithCycleNoRoot]

--- a/lib/CardRelationManager.ts
+++ b/lib/CardRelationManager.ts
@@ -183,6 +183,8 @@ class CardRelationManagerSingleton extends SupabaseManager<CardRelation> {
         this.traverse(child, direction, forEach, onCycle, visited)
       }
     }
+
+    visited.delete(from)
   }
 }
 


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

### Release Notes

- **Test**: Added a new test case to `CardRelationManager` to ensure the `set` function handles non-cyclic relations without errors.
- **Bug Fix**: Fixed an issue in `CardRelationManagerSingleton` where nodes were not properly removed from the `visited` set after traversal, preventing potential false positives for cyclic dependencies.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->