### PR TITLE
Update publish_update.yml

### DIFF
--- a/.github/workflows/publish_update.yml
+++ b/.github/workflows/publish_update.yml
@@ -18,6 +18,8 @@ jobs:
       EXPO_PROJECT: ${{ vars.EXPO_PROJECT }}
       EXPO_PUBLIC_SB_URL: ${{ vars.SUPABASE_URL }}
       EXPO_PUBLIC_SB_ANON: ${{ secrets.SUPABASE_ANON }}
+      EXPO_PUBLIC_RC_KEY_APPLE: ${{ secrets.REVENUECAT_APPLE }}
+      EXPO_PUBLIC_RC_KEY_GOOGLE: ${{ secrets.REVENUECAT_GOOGLE }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

### Release Notes

- **Chore**: Added new environment variables `EXPO_PUBLIC_RC_KEY_APPLE` and `EXPO_PUBLIC_RC_KEY_GOOGLE` to the GitHub Actions workflow for publishing updates. These variables are sourced from GitHub secrets, enhancing the security and configuration management of the deployment process.
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->