### PR TITLE
Starting and ending cards

### DIFF
--- a/__tests__/lib/CardManager.test.ts
+++ b/__tests__/lib/CardManager.test.ts
@@ -455,4 +455,61 @@ describe('drawCard', () => {
     expect(result?.featuredPlayers).toEqual(new Set([players[0], players[2]]))
     expect(result?.players).toEqual([players[2], players[0], players[1], players[3]])
   })
+
+  it('should always return starting cards first', () => {
+    const cards: Set<Card> = new Set([
+      {
+        ...MockedCards.Card_2,
+        order: 'ending',
+      },
+      {
+        ...MockedCards.Card_1,
+        order: 'starting',
+      },
+    ])
+
+    CardManager['set'](cards)
+    const playlist: Set<Pack> = new Set([
+      {
+        cards: new Set(['1', '2']),
+      } as Pack,
+    ])
+    const players = new Set([MockedPlayers.Alice, MockedPlayers.Bob])
+
+    const result = CardManager.drawCard([], new Set(), playlist, players, new Set())
+
+    expect(result?.id).toBe('1')
+  })
+
+  it('should only return ending cards if no other cards are available', () => {
+    const cards: Set<Card> = new Set([
+      {
+        ...MockedCards.Card_1,
+        order: 'starting',
+      },
+      MockedCards.Card_2,
+      {
+        ...MockedCards.Card_3,
+        order: 'ending',
+      },
+    ])
+
+    CardManager['set'](cards)
+    const playlist: Set<Pack> = new Set([
+      {
+        cards: new Set(['1', '2', '3']),
+      } as Pack,
+    ])
+    const players = new Set([MockedPlayers.Alice, MockedPlayers.Bob])
+
+    const result = CardManager.drawCard(
+      [MockedCards.Card_1 as PlayedCard, MockedCards.Card_2 as PlayedCard],
+      new Set(['1', '2']),
+      playlist,
+      players,
+      new Set()
+    )
+
+    expect(result?.id).toBe('3')
+  })
 })

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,7 @@
 sonar.projectKey=brisen-app_brisen-client_26c99873-d531-464d-a9a9-0ea569442bdd
 
 sonar.inclusions=src/**/*
+sonar.exclusions=src/models/supabase.ts
 
 sonar.coverage.exclusions=src/app/**/*,src/components/**/*,src/models/supabase.ts,src/providers/**/*
 

--- a/src/models/supabase.ts
+++ b/src/models/supabase.ts
@@ -90,6 +90,7 @@ export type Database = {
           id: string
           is_group: boolean
           modified_at: string
+          order: Database["public"]["Enums"]["card_order"] | null
         }
         Insert: {
           category?: string | null
@@ -99,6 +100,7 @@ export type Database = {
           id?: string
           is_group?: boolean
           modified_at?: string
+          order?: Database["public"]["Enums"]["card_order"] | null
         }
         Update: {
           category?: string | null
@@ -108,6 +110,7 @@ export type Database = {
           id?: string
           is_group?: boolean
           modified_at?: string
+          order?: Database["public"]["Enums"]["card_order"] | null
         }
         Relationships: [
           {
@@ -284,7 +287,7 @@ export type Database = {
       [_ in never]: never
     }
     Enums: {
-      [_ in never]: never
+      card_order: "starting" | "ending"
     }
     CompositeTypes: {
       [_ in never]: never
@@ -372,4 +375,19 @@ export type Enums<
   ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
   : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
     ? PublicSchema["Enums"][PublicEnumNameOrOptions]
+    : never
+
+export type CompositeTypes<
+  PublicCompositeTypeNameOrOptions extends
+    | keyof PublicSchema["CompositeTypes"]
+    | { schema: keyof Database },
+  CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
+    schema: keyof Database
+  }
+    ? keyof Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    : never = never,
+> = PublicCompositeTypeNameOrOptions extends { schema: keyof Database }
+  ? Database[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof PublicSchema["CompositeTypes"]
+    ? PublicSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

# Changes

> Provide a concise bullet-point summary of the key changes.

- Added new test cases to `CardManager.test.ts` to verify the behavior of the `drawCard` function with starting and ending cards.
- Enhanced `CardManager.ts` to prioritize "starting" and "ending" cards by introducing logic for ordering and managing these cards separately.
- Updated the database model in `supabase.ts` to include a new enum type `card_order` and an optional `order` field for handling card order in database operations.
- Modified `app.config.ts` to update the `runtimeVersion` configuration and change icon paths for iOS.

## Dependencies

> List any updates to dependencies. Remember to update the runtime version if dependencies are added or updated to a major version.

- No dependency updates were mentioned.

## Related issue(s)

> Please '#' the issue number(s) that are fixed by this PR.

- ...

### Checklist

- [ ] I have made changes to assets, `app.config.ts` or `package.json` and updated the `runtimeVersion` in the `app.config.ts`
- [ ] I have provided unit tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings and I have formatted my code with [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
- [ ] I have made necessary changes to the [README](README.md)
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->