### PR TITLE
Fix duplicated share URL iOS

### DIFF
--- a/__tests__/lib/CardManager.test.ts
+++ b/__tests__/lib/CardManager.test.ts
@@ -6,6 +6,8 @@ import { Pack, PackManager } from '@/src/managers/PackManager'
 import { InsufficientCountError } from '@/src/models/Errors'
 import { Player } from '@/src/models/Player'
 
+//#region Mocks
+
 const MockedCards = {
   Card_1: { id: '1', category: 'cat1', content: 'Content of card 1', is_group: true } as Card,
   Card_2: { id: '2', category: 'cat2', content: 'Content of card 2', is_group: true } as Card,
@@ -81,11 +83,15 @@ jest.mock('@/src/lib/supabase', () => ({
   },
 }))
 
+//#endregion
+
 beforeEach(() => {
   CardManager['_items'] = undefined
   CardManager['cachedPlayerCounts'].clear()
   jest.clearAllMocks()
 })
+
+//#region insertPlayers
 
 describe('insertPlayers', () => {
   it('should not change the content in place', () => {
@@ -118,6 +124,10 @@ describe('insertPlayers', () => {
     )
   })
 })
+
+//#endregion
+
+//#region getRequiredPlayerCount
 
 describe('getRequiredPlayerCount', () => {
   const testCases = [
@@ -164,6 +174,29 @@ describe('getRequiredPlayerCount', () => {
   })
 })
 
+//#endregion
+
+//#region getPlayableCards
+
+describe('getPlayableCards', () => {
+  beforeEach(() => {
+    CardManager['set'](Object.values(MockedCards))
+  })
+
+  it('should return cards that are playable based on player count and category filter', () => {
+    const categoryFilter = new Set(['cat1'])
+
+    const result = CardManager.getPlayableCards(MockedPacks.Pack_with_1_and_5_and_6, 2, categoryFilter)
+
+    expect(result.keys()).toContain(MockedCards.Card_5_req_2_players.id)
+    expect(result.size).toBe(1)
+  })
+})
+
+//#endregion
+
+//#region findCandidates
+
 describe('findCandidates', () => {
   beforeEach(() => {
     CardManager['set'](Object.values(MockedCards))
@@ -207,6 +240,10 @@ describe('findCandidates', () => {
   })
 })
 
+//#endregion
+
+//#region getNextCard
+
 describe('getNextCard', () => {
   beforeEach(() => {
     CardManager['set'](Object.values(MockedCards))
@@ -240,6 +277,10 @@ describe('getNextCard', () => {
     expect(result).toBeNull()
   })
 })
+
+//#endregion
+
+//#region drawClosingCard
 
 describe('drawClosingCard', () => {
   beforeEach(() => {
@@ -319,6 +360,10 @@ describe('drawClosingCard', () => {
   })
 })
 
+//#endregion
+
+//#region getParentPlayerList
+
 describe('getParentPlayerList', () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -363,6 +408,10 @@ describe('getParentPlayerList', () => {
     expect(result).toBeNull()
   })
 })
+
+//#endregion
+
+//#region drawCard
 
 describe('drawCard', () => {
   beforeEach(() => {
@@ -521,3 +570,5 @@ describe('drawCard', () => {
     expect(result?.id).toBe('3')
   })
 })
+
+//#endregion

--- a/__tests__/lib/PackManager.test.ts
+++ b/__tests__/lib/PackManager.test.ts
@@ -1,8 +1,6 @@
-import { Pack, PackManager } from '@/src/managers/PackManager'
 import { supabase } from '@/src/lib/supabase'
 import { ConfigurationManager } from '@/src/managers/ConfigurationManager'
-import { Card, CardManager } from '@/src/managers/CardManager'
-import { Player } from '@/src/models/Player'
+import { Pack, PackManager } from '@/src/managers/PackManager'
 
 const mockedSupabasePacks = [
   {
@@ -206,60 +204,20 @@ describe('getPacskOf', () => {
 })
 
 describe('isPlayable', () => {
-  it('should return true if the pack has enough available cards', () => {
-    const players = new Set([{ name: '1' }, { name: '2' }]) as Set<Player>
-    const categoryFilter = ['cat1']
+  const testCases = [
+    { minPlayableCards: 1, playableCardCount: 1, expected: true },
+    { minPlayableCards: 2, playableCardCount: 1, expected: false },
+    { minPlayableCards: 10, playableCardCount: 11, expected: true },
+    { minPlayableCards: 0, playableCardCount: 0, expected: false },
+  ]
 
-    jest.spyOn(ConfigurationManager, 'getValue').mockReturnValueOnce(1)
-    const spyOnRequiredPlayCount = jest
-      .spyOn(CardManager, 'getRequiredPlayerCount')
-      .mockReturnValueOnce(0)
-      .mockReturnValueOnce(10)
-    const spyOnGetCard = jest.spyOn(CardManager, 'get').mockReturnValue({ category: 'cat2' } as Card)
+  testCases.forEach(({ minPlayableCards, playableCardCount, expected }) => {
+    it(`should return ${expected} if playableCardCount is ${playableCardCount} and minPlayableCards is ${minPlayableCards}`, () => {
+      jest.spyOn(ConfigurationManager, 'getValue').mockReturnValueOnce(minPlayableCards)
 
-    const isPlayable = PackManager.isPlayable(mockedPacks[0], players, categoryFilter)
+      const isPlayable = PackManager.isPlayable(playableCardCount)
 
-    expect(spyOnGetCard).toHaveBeenCalledTimes(2)
-    expect(spyOnRequiredPlayCount).toHaveBeenCalledTimes(2)
-    expect(isPlayable).toBeTruthy()
-  })
-
-  it('should return false if there arent enough players', () => {
-    const players = new Set([{ name: '1' }, { name: '2' }]) as Set<Player>
-    const categoryFilter = ['cat1']
-
-    jest.spyOn(ConfigurationManager, 'getValue').mockReturnValueOnce(1)
-    jest.spyOn(CardManager, 'getRequiredPlayerCount').mockReturnValue(10)
-    jest.spyOn(CardManager, 'get').mockReturnValue({ category: 'cat2' } as Card)
-
-    const isPlayable = PackManager.isPlayable(mockedPacks[0], players, categoryFilter)
-
-    expect(isPlayable).toBeFalsy()
-  })
-
-  it('should return false if categories are filtered out', () => {
-    const players = new Set([{ name: '1' }, { name: '2' }]) as Set<Player>
-    const categoryFilter = ['cat1']
-
-    jest.spyOn(ConfigurationManager, 'getValue').mockReturnValueOnce(1)
-    jest.spyOn(CardManager, 'getRequiredPlayerCount').mockReturnValue(0)
-    jest.spyOn(CardManager, 'get').mockReturnValue({ category: 'cat1' } as Card)
-
-    const isPlayable = PackManager.isPlayable(mockedPacks[0], players, categoryFilter)
-
-    expect(isPlayable).toBeFalsy()
-  })
-
-  it('should return true if original amount of cards are less than limit', () => {
-    const players = new Set([{ name: '1' }, { name: '2' }]) as Set<Player>
-    const categoryFilter = ['cat2']
-
-    jest.spyOn(ConfigurationManager, 'getValue').mockReturnValueOnce(10)
-    jest.spyOn(CardManager, 'getRequiredPlayerCount').mockReturnValue(0)
-    jest.spyOn(CardManager, 'get').mockReturnValue({ category: 'cat1' } as Card)
-
-    const isPlayable = PackManager.isPlayable(mockedPacks[0], players, categoryFilter)
-
-    expect(isPlayable).toBeTruthy()
+      expect(isPlayable).toBe(expected)
+    })
   })
 })

--- a/src/components/MenuView.tsx
+++ b/src/components/MenuView.tsx
@@ -16,13 +16,11 @@ import {
 import { Picker } from '@react-native-picker/picker'
 import { useQueryClient } from '@tanstack/react-query'
 import * as Application from 'expo-application'
-import * as Clipboard from 'expo-clipboard'
 import * as Device from 'expo-device'
 import { Image } from 'expo-image'
 import { openSettings, openURL } from 'expo-linking'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import {
-  Alert,
   Dimensions,
   Keyboard,
   NativeSyntheticEvent,
@@ -386,11 +384,10 @@ function AppDetailsView() {
   const fontSize = 12
 
   const appName = LocalizationManager.get('app_name')?.value ?? 'app_name'
-  const copiedTitle = LocalizationManager.get('copied_to_clipboard')?.value ?? 'copied_to_clipboard'
 
   const handleLongPress = () => {
-    Clipboard.setStringAsync(userId ?? '')
-    Alert.alert(copiedTitle, userId ?? '')
+    if (!userId) return
+    Share.share({ message: userId })
   }
 
   return (

--- a/src/components/MenuView.tsx
+++ b/src/components/MenuView.tsx
@@ -313,7 +313,7 @@ function LinksView(props: Readonly<ViewProps>) {
       {
         title: shareTitle,
         url: storeURL,
-        message: `${shareMsg} ${storeURL}`,
+        message: shareMsg,
       },
       {
         dialogTitle: shareTitle,

--- a/src/components/MenuView.tsx
+++ b/src/components/MenuView.tsx
@@ -313,7 +313,10 @@ function LinksView(props: Readonly<ViewProps>) {
       {
         title: shareTitle,
         url: storeURL,
-        message: shareMsg,
+        message: Platform.select({
+          ios: shareMsg,
+          default: `${shareMsg} ${storeURL}`,
+        }),
       },
       {
         dialogTitle: shareTitle,

--- a/src/managers/CardManager.ts
+++ b/src/managers/CardManager.ts
@@ -123,6 +123,10 @@ class CardManagerSingleton extends SupabaseManager<Card> {
     return candidateCount === 0 ? getRandom(unplayedChildren.values()) : null
   }
 
+  getPlayableCards(pack: Pack, playerCount: number, categoryFilter: Set<string>) {
+    return this.findCandidates(new Set([pack]), new Set(), playerCount, categoryFilter)
+  }
+
   private findCandidates(
     playlist: Set<Pack>,
     playedIds: Set<string>,

--- a/src/managers/PackManager.ts
+++ b/src/managers/PackManager.ts
@@ -3,8 +3,6 @@ import { NotFoundError } from '@/src/models/Errors'
 import { Tables } from '@/src/models/supabase'
 import { useQuery } from '@tanstack/react-query'
 import { supabase } from '../lib/supabase'
-import { Player } from '../models/Player'
-import { CardManager } from './CardManager'
 import { ConfigurationManager } from './ConfigurationManager'
 import { LanguageManager } from './LanguageManager'
 import SupabaseManager from './SupabaseManager'
@@ -56,20 +54,9 @@ class PackManagerSingleton extends SupabaseManager<Pack> {
     return packs
   }
 
-  isPlayable(pack: Pack, players: Set<Player>, categoryFilter: string[]) {
+  isPlayable(playableCardCount: number) {
     const minPlayableCards = ConfigurationManager.getValue('min_playable_cards') ?? 10
-
-    const playableCardCount = pack.cards.filter(cardId => {
-      const card = CardManager.get(cardId)
-      if (!card) return false
-      if (card.category && categoryFilter.includes(card.category)) return false
-      if (CardManager.getRequiredPlayerCount(card) > players.size) return false
-      return true
-    }).length
-
-    if (playableCardCount === 0) return false
-    if (pack.cards.length < minPlayableCards) return true
-    return playableCardCount >= minPlayableCards
+    return playableCardCount > 0 && playableCardCount >= minPlayableCards
   }
 
   useImageQuery(imageName: string | null | undefined, enabled = true) {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

# Changes

> Provide a concise bullet-point summary of the key changes.

- Refactored test suites in `__tests__/lib/CardManager.test.ts` and `__tests__/lib/PackManager.test.ts` to improve readability and reduce redundancy by using region markers and parameterized tests.
- Updated `src/components/MenuView.tsx` to replace `expo-clipboard` and `Alert` with `Share.share` for sharing user IDs, simplifying the message format.
- Enhanced logic in `src/components/pack/PackPosterView.tsx` by introducing an `isSelectable` variable to streamline conditions and update UI elements based on pack status.
- Added a new method `getPlayableCards` in `src/managers/CardManager.ts` and refactored `isPlayable` in `src/managers/PackManager.ts` to simplify playability checks and remove unused imports.

## Dependencies

> List any updates to dependencies. Remember to update the runtime version if dependencies are added or updated to a major version.

- No updates to dependencies.

## Related issue(s)

> Please '#' the issue number(s) that are fixed by this PR.

- ...

### Checklist

- [ ] I have made changes to assets, `app.config.ts` or `package.json` and updated the `runtimeVersion` in the `app.config.ts`
- [ ] I have provided unit tests that prove my fix is effective or that my feature works
- [x] My changes generate no new warnings and I have formatted my code with [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
- [x] I have made necessary changes to the [README](README.md)
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->