### PR TITLE
Prioritise card header over category title

### DIFF
--- a/src/components/card/CardView.tsx
+++ b/src/components/card/CardView.tsx
@@ -147,7 +147,7 @@ function Content(props: Readonly<{ content: string; player?: Player } & ViewProp
 function CategoryLabel(props: Readonly<{ item?: Category; header?: string; iconSize?: number } & ViewProps>) {
   const { item, header, iconSize = 48, style, ...rest } = props
 
-  const categoryTitle = item ? CategoryManager.getTitle(item) : header
+  const categoryTitle = item ? CategoryManager.getTitle(item) : null
 
   return (
     <View
@@ -157,9 +157,12 @@ function CategoryLabel(props: Readonly<{ item?: Category; header?: string; iconS
       {item?.icon && <Text style={[styles.textShadow, { fontSize: iconSize }]}>{item?.icon}</Text>}
 
       <View>
-        {categoryTitle && (
-          <Text style={[FontStyles.Title, styles.textShadow, { color: Color.white.string }]}>{categoryTitle}</Text>
-        )}
+        {categoryTitle ||
+          (header && (
+            <Text style={[FontStyles.Title, styles.textShadow, { color: Color.white.string }]}>
+              {header ?? categoryTitle}
+            </Text>
+          ))}
       </View>
     </View>
   )

--- a/src/components/card/CardView.tsx
+++ b/src/components/card/CardView.tsx
@@ -157,12 +157,11 @@ function CategoryLabel(props: Readonly<{ item?: Category; header?: string; iconS
       {item?.icon && <Text style={[styles.textShadow, { fontSize: iconSize }]}>{item?.icon}</Text>}
 
       <View>
-        {categoryTitle ||
-          (header && (
-            <Text style={[FontStyles.Title, styles.textShadow, { color: Color.white.string }]}>
-              {header ?? categoryTitle}
-            </Text>
-          ))}
+        {(categoryTitle || header) && (
+          <Text style={[FontStyles.Title, styles.textShadow, { color: Color.white.string }]}>
+            {header ?? categoryTitle}
+          </Text>
+        )}
       </View>
     </View>
   )


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

# Changes

> Provide a concise bullet-point summary of the key changes.

- Modified the `CategoryLabel` component logic to prioritize displaying the `header` over the `categoryTitle`.
- Updated rendering logic to check for `categoryTitle` first and fall back to `header` if `categoryTitle` is not available.
- Adjusted how the component retrieves the title using `CategoryManager.getTitle(item)` when `item` is present, otherwise setting `categoryTitle` to `null`.

## Dependencies

> List any changes to dependencies. If a new dependency is added, please provide a brief description of why.

- No changes to dependencies.

## Related issue(s)

> Please '#' any issues that are related to the changes in this PR.

- #42 

### Checklist

> Please check the following items before submitting your PR.

- [ ] I have made changes that require a new build to be submitted to stores. Such changes include
  - Adding or updating dependencies to a non-patch version
  - Adding or updating `assets`
  - Making changes to `app.config.ts` or `babel.config.js`
- [ ] I have made the necessary changes to the [README](README.md)
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->